### PR TITLE
[#1] Manual stage execution

### DIFF
--- a/src/main/groovy/info/solidsoft/jenkins/powerstage/stage/PowerStageConfig.groovy
+++ b/src/main/groovy/info/solidsoft/jenkins/powerstage/stage/PowerStageConfig.groovy
@@ -22,4 +22,5 @@ class PowerStageConfig implements PowerStageConfigView {
     private static final int DEFAULT_MAXIMUM_NUMBER_OF_ATTEMPTS = 3
 
     int maximumNumberOfAttempts = DEFAULT_MAXIMUM_NUMBER_OF_ATTEMPTS
+    StageExecutionMode stageExecutionMode = StageExecutionMode.AUTO
 }

--- a/src/main/groovy/info/solidsoft/jenkins/powerstage/stage/PowerStageConfigView.groovy
+++ b/src/main/groovy/info/solidsoft/jenkins/powerstage/stage/PowerStageConfigView.groovy
@@ -18,4 +18,5 @@ package info.solidsoft.jenkins.powerstage.stage
 interface PowerStageConfigView {
 
     int getMaximumNumberOfAttempts()
+    StageExecutionMode getStageExecutionMode()
 }

--- a/src/main/groovy/info/solidsoft/jenkins/powerstage/stage/PowerStageCreator.groovy
+++ b/src/main/groovy/info/solidsoft/jenkins/powerstage/stage/PowerStageCreator.groovy
@@ -39,6 +39,14 @@ class PowerStageCreator {
 
         executeInScriptContext {
 
+            if (config.stageExecutionMode == StageExecutionMode.MANUAL) {
+                stage("${stageName} approval") {
+                    //TODO: Add notifications about awaiting approval
+                    input id: "${stageName.toLowerCase()}ApprovalInput", message: "Execute ${stageName}?"
+                }
+                milestone nextMilestoneNumber++
+            }
+
             stage(stageName) {
                 echo "Executing stage ${stageName}"
                 milestone nextMilestoneNumber++

--- a/src/main/groovy/info/solidsoft/jenkins/powerstage/stage/StageExecutionMode.groovy
+++ b/src/main/groovy/info/solidsoft/jenkins/powerstage/stage/StageExecutionMode.groovy
@@ -1,0 +1,5 @@
+package info.solidsoft.jenkins.powerstage.stage;
+
+enum StageExecutionMode {
+    AUTO, MANUAL
+}


### PR DESCRIPTION
Allows to create stages which require a manual approval (e.g. a deployment to production).

This feature was sponsored by Play Mobile.

Closes: #1.